### PR TITLE
refactoring  다이어리-해시태그

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @RequiredArgsConstructor
@@ -42,8 +43,9 @@ public class PersonalExerciseDiaryController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         DiaryResponse diary = diaryService.saveDiaryWithHashtags(
-                request.toDto(userDetails.toDto()), request.hashtagDtoSet()
-        );
+                request.toDto(userDetails.toDto()),
+                request.hashtags().stream()
+                        .map(HashtagDto::of).collect(Collectors.toUnmodifiableSet()));
         return ResponseEntity.ok(diary);
     }
 

--- a/src/main/java/com/bodytok/healthdiary/domain/Hashtag.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/Hashtag.java
@@ -36,13 +36,15 @@ public class Hashtag {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Hashtag hashtag = (Hashtag) o;
-        return Objects.equals(id, hashtag.id);
+        if (!(o instanceof Hashtag)) return false;
+        Hashtag that = (Hashtag) o;
+        // id가 null이면 hashtag 필드를 기준으로 비교, 아니면 id 필드를 기준으로 비교
+        return (id == null) ? Objects.equals(hashtag, that.hashtag) : Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        // id가 null이면 hashtag 필드로 해시 코드 생성, 아니면 id 필드로 해시 코드 생성
+        return (id == null) ? Objects.hash(hashtag) : Objects.hash(id);
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/domain/security/CustomUserDetails.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/security/CustomUserDetails.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
+    private Long id;
     private String email;
     private String nickname;
     private String userPassword;
@@ -26,9 +27,25 @@ public class CustomUserDetails implements UserDetails {
     private Collection<? extends GrantedAuthority> authorities;
 
 
+    private static final Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
     public static CustomUserDetails of(String email,String nickname, String userPassword,  Byte[] profileImage) {
-        Set<RoleType> roleTypes = Set.of(RoleType.USER);
         return new CustomUserDetails(
+                null,
+                email,
+                nickname,
+                userPassword,
+                profileImage,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet())
+        );
+    }
+
+    public static CustomUserDetails of(Long id, String email,String nickname, String userPassword,  Byte[] profileImage) {
+        return new CustomUserDetails(
+                id,
                 email,
                 nickname,
                 userPassword,
@@ -42,6 +59,7 @@ public class CustomUserDetails implements UserDetails {
 
     public static CustomUserDetails from(UserAccountDto dto) {
         return CustomUserDetails.of(
+                dto.id(),
                 dto.email(),
                 dto.nickname(),
                 dto.userPassword(),
@@ -59,6 +77,7 @@ public class CustomUserDetails implements UserDetails {
     }
     public UserAccountDto toDto() {
         return UserAccountDto.of(
+                id,
                 email,
                 nickname,
                 userPassword,

--- a/src/main/java/com/bodytok/healthdiary/dto/UserAccountDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/UserAccountDto.java
@@ -22,6 +22,9 @@ public record UserAccountDto(
     public static UserAccountDto of(String email, String nickname, String userPassword, Byte[] profileImage) {
         return new UserAccountDto(null, email, nickname, userPassword, profileImage, null, null);
     }
+    public static UserAccountDto of(Long id,String email, String nickname, String userPassword, Byte[] profileImage) {
+        return new UserAccountDto(id, email, nickname, userPassword, profileImage, null, null);
+    }
 
     public static UserAccountDto from(UserAccount entity) {
         return new UserAccountDto(

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/request/DiaryRequest.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/request/DiaryRequest.java
@@ -8,19 +8,21 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 public record DiaryRequest(
-    PersonalExerciseDiaryDto diaryDto,
-    Set<HashtagDto> hashtagDtoSet
+    String title,
+    String content,
+    Boolean isPublic,
+    Set<String> hashtags
 ) {
-    public static DiaryRequest of(PersonalExerciseDiaryDto diaryDto, Set<HashtagDto> hashtagDtoSet) {
-        return new DiaryRequest(diaryDto, hashtagDtoSet);
+    public static DiaryRequest of(String title, String content, Boolean isPublic, Set<String> hashtags) {
+        return new DiaryRequest(title,content,isPublic, hashtags);
     }
 
     public PersonalExerciseDiaryDto toDto(UserAccountDto userAccountDto) {
         return PersonalExerciseDiaryDto.of(
                 userAccountDto,
-                diaryDto.title(),
-                diaryDto.content(),
-                diaryDto.isPublic()
+                title(),
+                content(),
+                isPublic()
         );
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryResponse.java
@@ -15,14 +15,15 @@ public record DiaryResponse(
         Boolean isPublic,
         Integer totalExTime,
         LocalDateTime createAt,
+        Long userId,
         String email,
         String nickname,
-        Set<HashtagDto> hashtagDtoSet
+        Set<HashtagDto> hashtags
 
 ) {
 
-    public static DiaryResponse of(Long id, String title, String content, Boolean isPublic, Integer totalExTime, LocalDateTime createAt, String email, String nickname, Set<HashtagDto> hashtagDtoSet){
-        return new DiaryResponse(id, title, content, isPublic, totalExTime, createAt, email, nickname, hashtagDtoSet);
+    public static DiaryResponse of(Long id, String title, String content, Boolean isPublic, Integer totalExTime, LocalDateTime createAt,Long userId, String email, String nickname, Set<HashtagDto> hashtags){
+        return new DiaryResponse(id, title, content, isPublic, totalExTime, createAt,userId, email, nickname, hashtags);
 
     }
 
@@ -39,6 +40,7 @@ public record DiaryResponse(
                 dto.isPublic(),
                 dto.totalExTime(),
                 dto.createdAt(),
+                dto.userAccountDto().id(),
                 dto.userAccountDto().email(),
                 nickname,
                 hashtags

--- a/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
@@ -67,11 +67,16 @@ public class PersonalExerciseDiaryService {
 
     public DiaryResponse saveDiaryWithHashtags(PersonalExerciseDiaryDto dto, Set<HashtagDto> hashtagDtoSet) {
         // Convert DTOs to entities
+
+        log.info("user id : {}", dto.userAccountDto().id());
+        log.info("hashtags set : {}", hashtagDtoSet);
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().id());
         PersonalExerciseDiary diary = dto.toEntity(userAccount);
         Set<Hashtag> hashtags = hashtagDtoSet.stream()
                 .map(HashtagDto::toEntity)
                 .collect(Collectors.toUnmodifiableSet());
+
+        log.info("hashtags after of() : {}", hashtags);
         // Save diary and hashtags
         diary = diaryRepository.save(diary);
         hashtags = hashtags.stream().map(hashtagRepository::save).collect(Collectors.toUnmodifiableSet());


### PR DESCRIPTION
로그인을 구현하면서, 인증된 유저로 다이어리를 작성하는 로직을 점검했는데 많은 오류가 있었다.
* CustomUserDetails 에 userId 를 추가
* DiaryResponse  에도 userId 를 추가
* 다이어리 저장 시 해시태그 객체를 생성하고 stream() 이 실행될 때, id 가 모두 null 이어서 중복으로 검사가 되었음. -> 동등성 비교 코드 변경