### PR TITLE
 리팩토링 - 다이어리 dto 등 클래스, record 의 이름을 바꾸기

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -2,8 +2,6 @@ package com.bodytok.healthdiary.controller;
 
 
 import com.bodytok.healthdiary.domain.security.CustomUserDetails;
-import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryDto;
-import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryWithCommentDto;
 import com.bodytok.healthdiary.dto.diary.request.DiaryRequest;
 import com.bodytok.healthdiary.dto.diary.response.DiaryResponse;
 import com.bodytok.healthdiary.dto.diary.response.DiaryWithCommentResponse;
@@ -17,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Set;
 import java.util.stream.Collectors;
 
 

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryDto.java
@@ -1,18 +1,15 @@
 package com.bodytok.healthdiary.dto.diary;
 
-import com.bodytok.healthdiary.domain.Hashtag;
 import com.bodytok.healthdiary.domain.PersonalExerciseDiary;
 import com.bodytok.healthdiary.domain.UserAccount;
 import com.bodytok.healthdiary.dto.UserAccountDto;
-import com.bodytok.healthdiary.dto.hashtag.HashtagDto;
 
 import java.time.LocalDateTime;
-import java.util.Set;
 
 /**
  * DTO for {@link PersonalExerciseDiary}
  */
-public record PersonalExerciseDiaryDto(
+public record DiaryDto(
         Long id,
         UserAccountDto userAccountDto,
         String title,
@@ -24,12 +21,12 @@ public record PersonalExerciseDiaryDto(
 
 ) {
 
-    public static PersonalExerciseDiaryDto of(UserAccountDto userAccountDto, String title, String content, Boolean isPublic) {
-        return new PersonalExerciseDiaryDto(null, userAccountDto, title, content, 0, isPublic, null, null);
+    public static DiaryDto of(UserAccountDto userAccountDto, String title, String content, Boolean isPublic) {
+        return new DiaryDto(null, userAccountDto, title, content, 0, isPublic, null, null);
     }
 
-    public static PersonalExerciseDiaryDto from(PersonalExerciseDiary entity) {
-        return new PersonalExerciseDiaryDto(
+    public static DiaryDto from(PersonalExerciseDiary entity) {
+        return new DiaryDto(
                 entity.getId(),
                 UserAccountDto.from(entity.getUserAccount()),
                 entity.getTitle(),

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryWithCommentDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryWithCommentDto.java
@@ -9,7 +9,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public record PersonalExerciseDiaryWithCommentDto(
+public record DiaryWithCommentDto(
         Long id,
         UserAccountDto userAccountDto,
         Set<CommentDto> commentDtoSet,
@@ -21,12 +21,12 @@ public record PersonalExerciseDiaryWithCommentDto(
         LocalDateTime modifiedAt
 ) {
 
-    public static PersonalExerciseDiaryWithCommentDto of(Long id, UserAccountDto userAccountDto, Set<CommentDto> commentDtoSet, String title, String content, Integer totalExTime,  Boolean isPublic, LocalDateTime createdAt, LocalDateTime modifiedAt) {
-        return new PersonalExerciseDiaryWithCommentDto(id, userAccountDto, commentDtoSet, title, content, totalExTime, isPublic, createdAt, modifiedAt);
+    public static DiaryWithCommentDto of(Long id, UserAccountDto userAccountDto, Set<CommentDto> commentDtoSet, String title, String content, Integer totalExTime, Boolean isPublic, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new DiaryWithCommentDto(id, userAccountDto, commentDtoSet, title, content, totalExTime, isPublic, createdAt, modifiedAt);
     }
 
-    public static PersonalExerciseDiaryWithCommentDto from(PersonalExerciseDiary entity) {
-        return new PersonalExerciseDiaryWithCommentDto(
+    public static DiaryWithCommentDto from(PersonalExerciseDiary entity) {
+        return new DiaryWithCommentDto(
                 entity.getId(),
                 UserAccountDto.from(entity.getUserAccount()),
                 entity.getComments().stream()

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/request/DiaryRequest.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/request/DiaryRequest.java
@@ -1,10 +1,8 @@
 package com.bodytok.healthdiary.dto.diary.request;
 
 import com.bodytok.healthdiary.dto.UserAccountDto;
-import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryDto;
-import com.bodytok.healthdiary.dto.hashtag.HashtagDto;
+import com.bodytok.healthdiary.dto.diary.DiaryDto;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public record DiaryRequest(
@@ -17,8 +15,8 @@ public record DiaryRequest(
         return new DiaryRequest(title,content,isPublic, hashtags);
     }
 
-    public PersonalExerciseDiaryDto toDto(UserAccountDto userAccountDto) {
-        return PersonalExerciseDiaryDto.of(
+    public DiaryDto toDto(UserAccountDto userAccountDto) {
+        return DiaryDto.of(
                 userAccountDto,
                 title(),
                 content(),

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryResponse.java
@@ -1,12 +1,10 @@
 package com.bodytok.healthdiary.dto.diary.response;
 
-import com.bodytok.healthdiary.domain.Hashtag;
-import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryDto;
+import com.bodytok.healthdiary.dto.diary.DiaryDto;
 import com.bodytok.healthdiary.dto.hashtag.HashtagDto;
 
 import java.time.LocalDateTime;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public record DiaryResponse(
         Long id,
@@ -27,7 +25,7 @@ public record DiaryResponse(
 
     }
 
-    public static DiaryResponse from(PersonalExerciseDiaryDto dto, Set<HashtagDto> hashtags) {
+    public static DiaryResponse from(DiaryDto dto, Set<HashtagDto> hashtags) {
         String nickname = dto.userAccountDto().nickname();
         if (nickname == null || nickname.isBlank()) {
             nickname = dto.userAccountDto().email();

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryWithCommentResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryWithCommentResponse.java
@@ -1,8 +1,12 @@
 package com.bodytok.healthdiary.dto.diary.response;
 
 import com.bodytok.healthdiary.dto.comment.CommentResponse;
+<<<<<<< Updated upstream
 import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryWithCommentDto;
 import com.bodytok.healthdiary.dto.hashtag.HashtagDto;
+=======
+import com.bodytok.healthdiary.dto.diary.DiaryWithCommentDto;
+>>>>>>> Stashed changes
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
@@ -28,7 +32,11 @@ public record DiaryWithCommentResponse(
 
     }
 
+<<<<<<< Updated upstream
     public static DiaryWithCommentResponse from(PersonalExerciseDiaryWithCommentDto dto, Set<HashtagDto> hashtags) {
+=======
+    public static DiaryWithCommentResponse from(DiaryWithCommentDto dto) {
+>>>>>>> Stashed changes
         String nickname = dto.userAccountDto().nickname();
         if (nickname == null || nickname.isBlank()) {
             nickname = dto.userAccountDto().email();

--- a/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
@@ -2,9 +2,14 @@ package com.bodytok.healthdiary.service;
 
 
 import com.bodytok.healthdiary.domain.*;
+<<<<<<< Updated upstream
 import com.bodytok.healthdiary.dto.diary.DiaryWithHashtag;
 import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryDto;
 import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryWithCommentDto;
+=======
+import com.bodytok.healthdiary.dto.diary.DiaryDto;
+import com.bodytok.healthdiary.dto.diary.DiaryWithCommentDto;
+>>>>>>> Stashed changes
 import com.bodytok.healthdiary.dto.diary.response.DiaryResponse;
 import com.bodytok.healthdiary.dto.diary.response.DiaryWithCommentResponse;
 import com.bodytok.healthdiary.dto.hashtag.HashtagDto;
@@ -20,7 +25,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,7 +46,12 @@ public class PersonalExerciseDiaryService {
                 .map(PersonalExerciseDiaryHashtag::getHashtag)
                 .collect(Collectors.toUnmodifiableSet());
 
+<<<<<<< Updated upstream
         return DiaryWithHashtag.of(diary, hashtags.stream().map(HashtagDto::from).collect(Collectors.toUnmodifiableSet()));
+=======
+        DiaryDto diaryDto = DiaryDto.from(diary);
+        return DiaryResponse.from(diaryDto, hashtags.stream().map(HashtagDto::from).collect(Collectors.toUnmodifiableSet()));
+>>>>>>> Stashed changes
     }
 
     @Transactional(readOnly = true)
@@ -54,23 +63,35 @@ public class PersonalExerciseDiaryService {
     }
 
     @Transactional(readOnly = true)
+<<<<<<< Updated upstream
     public DiaryResponse getDiary(Long diaryId) {
         var diary = diaryRepository.findById(diaryId);
         return diary.map(this::convertToDtoWithHashtags)
                 .map(DiaryWithHashtag::toDiaryResponse)
+=======
+    public DiaryDto getDiary(Long diaryId) {
+        return diaryRepository.findById(diaryId)
+                .map(DiaryDto::from)
+>>>>>>> Stashed changes
                 .orElseThrow(() -> new EntityNotFoundException("다이어리가 없습니다. - diaryId : "+ diaryId));
     }
 
     @Transactional(readOnly = true)
+<<<<<<< Updated upstream
     public DiaryWithCommentResponse getDiaryWithComments(Long diaryId) {
         var diary = diaryRepository.findById(diaryId);
         return diary.map(this::convertToDtoWithHashtags)
                 .map(DiaryWithHashtag::toDiaryWithCommentResponse)
+=======
+    public DiaryWithCommentDto getDiaryWithComments(Long diaryId) {
+        return diaryRepository.findById(diaryId)
+                .map(DiaryWithCommentDto::from)
+>>>>>>> Stashed changes
                 .orElseThrow(() -> new EntityNotFoundException("다이어리가 없습니다. - diaryId : "+ diaryId));
     }
 
 
-    public DiaryResponse saveDiaryWithHashtags(PersonalExerciseDiaryDto dto, Set<HashtagDto> hashtagDtoSet) {
+    public DiaryResponse saveDiaryWithHashtags(DiaryDto dto, Set<HashtagDto> hashtagDtoSet) {
         // Convert DTOs to entities
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().id());
         PersonalExerciseDiary diary = dto.toEntity(userAccount);
@@ -93,12 +114,12 @@ public class PersonalExerciseDiaryService {
         }
 
         return DiaryResponse.from(
-                PersonalExerciseDiaryDto.from(diary),
+                DiaryDto.from(diary),
                 hashtags.stream().map(HashtagDto::from).collect(Collectors.toUnmodifiableSet())
         );
     }
 
-    public void updateDiary(PersonalExerciseDiaryDto dto) {
+    public void updateDiary(DiaryDto dto) {
         try {
             PersonalExerciseDiary diary = diaryRepository.getReferenceById(dto.id());
             if (dto.title() != null) { diary.setTitle(dto.title()); }

--- a/src/test/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryControllerTest.java
+++ b/src/test/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryControllerTest.java
@@ -1,7 +1,7 @@
 package com.bodytok.healthdiary.controller;
 
 import com.bodytok.healthdiary.config.TestSecurityConfig;
-import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryDto;
+import com.bodytok.healthdiary.dto.diary.DiaryDto;
 import com.bodytok.healthdiary.dto.UserAccountDto;
 import com.bodytok.healthdiary.service.PersonalExerciseDiaryService;
 import com.bodytok.healthdiary.service.jwt.JwtService;
@@ -124,8 +124,8 @@ class PersonalExerciseDiaryControllerTest {
 
 
 
-    private PersonalExerciseDiaryDto createDiaryDto() {
-        return PersonalExerciseDiaryDto.of(
+    private DiaryDto createDiaryDto() {
+        return DiaryDto.of(
                 createUserAccountDto(),
                 "title",
                 "content",

--- a/src/test/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryServiceTest.java
+++ b/src/test/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryServiceTest.java
@@ -2,7 +2,7 @@ package com.bodytok.healthdiary.service;
 
 import com.bodytok.healthdiary.domain.PersonalExerciseDiary;
 import com.bodytok.healthdiary.domain.UserAccount;
-import com.bodytok.healthdiary.dto.diary.PersonalExerciseDiaryDto;
+import com.bodytok.healthdiary.dto.diary.DiaryDto;
 import com.bodytok.healthdiary.dto.UserAccountDto;
 import com.bodytok.healthdiary.repository.PersonalExerciseDiaryRepository;
 import com.bodytok.healthdiary.repository.UserAccountRepository;
@@ -42,7 +42,7 @@ class PersonalExerciseDiaryServiceTest {
         Pageable pageable = Pageable.ofSize(20);
         given(diaryRepository.findAll(pageable)).willReturn(Page.empty());
         //When
-        Page<PersonalExerciseDiaryDto> diaries = sut.getAllDiaries(pageable);
+        Page<DiaryDto> diaries = sut.getAllDiaries(pageable);
         //Then
 
         assertThat(diaries).isNotNull();
@@ -57,7 +57,7 @@ class PersonalExerciseDiaryServiceTest {
         PersonalExerciseDiary diary = createPersonalExerciseDiary();
         given(diaryRepository.findById(diaryId)).willReturn(Optional.of(diary));
         //When
-        PersonalExerciseDiaryDto dto = sut.getDiary(diaryId);
+        DiaryDto dto = sut.getDiary(diaryId);
         //Then
 
         then(diaryRepository).should().findById(diaryId);
@@ -81,7 +81,7 @@ class PersonalExerciseDiaryServiceTest {
     @DisplayName("다이어리 정보를 입력하면, 저장한다.")
     @Test
     void givenDiaryInfo_whenCreatingANewDiary_thenSavesIt() {
-        PersonalExerciseDiaryDto dto = createDiaryDto();
+        DiaryDto dto = createDiaryDto();
         given(diaryRepository.save(any(PersonalExerciseDiary.class))).willReturn(createPersonalExerciseDiary());
         // When
         sut.saveDiary(dto);
@@ -96,7 +96,7 @@ class PersonalExerciseDiaryServiceTest {
     void givenArticleIdAndModifiedInfo_whenUpdatingArticle_thenUpdatesArticle() {
         // Given
         PersonalExerciseDiary diary = createPersonalExerciseDiary();
-        PersonalExerciseDiaryDto dto = createDiaryDto("새 타이틀", "새 내용", false,"");
+        DiaryDto dto = createDiaryDto("새 타이틀", "새 내용", false,"");
         given(diaryRepository.getReferenceById(dto.id())).willReturn(diary);
         // When
         sut.updateDiary(dto);
@@ -153,12 +153,12 @@ class PersonalExerciseDiaryServiceTest {
         return diary;
     }
 
-    private PersonalExerciseDiaryDto createDiaryDto() {
+    private DiaryDto createDiaryDto() {
         return createDiaryDto("title", "content", false, "testurl");
     }
 
-    private PersonalExerciseDiaryDto createDiaryDto(String title, String content, Boolean isPublic, String youtubeUrl) {
-        return PersonalExerciseDiaryDto.of(
+    private DiaryDto createDiaryDto(String title, String content, Boolean isPublic, String youtubeUrl) {
+        return DiaryDto.of(
                 createUserAccountDto(),
                 title,
                 content,


### PR DESCRIPTION
PersonalExerciseDiary 는 너무 길다.
테이블과 연관있는 도메인과, 레포지토리의 이름을 그대로 두고dto 들의 이름만 변경함.

This  closes #39 