### PR TITLE
JwtAuthenticationFilter 에러

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true); // 클라이언트가 쿠키를 전송할 수 있도록 허용
-        config.addAllowedOrigin("*"); // 모든 출처를 허용 (실제 배포 시에는 필요한 출처만 허용해야 함)
+        config.addAllowedOrigin("http://localhost:3000"); // 모든 출처를 허용 (실제 배포 시에는 필요한 출처만 허용해야 함)
         config.addAllowedHeader("*"); // 모든 헤더 허용
         config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
 

--- a/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtAuthenticationFilter.java
@@ -1,22 +1,26 @@
 package com.bodytok.healthdiary.filter.jwt;
 
 import com.bodytok.healthdiary.service.jwt.JwtService;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -35,27 +39,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String jwt;
         final String userEmail;
 
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-        jwt = authHeader.substring(7);
-        userEmail = jwtService.extractUsername(jwt);
-        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
-            //
-            if (jwtService.isTokenValid(jwt, userDetails)) {
-                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-                authToken.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request)
-                );
-                SecurityContextHolder.getContext().setAuthentication(authToken);
+        try{
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                filterChain.doFilter(request, response);
+                return;
             }
+            jwt = authHeader.substring(7);
+            userEmail = jwtService.extractUsername(jwt);
+            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
+                //
+                if (jwtService.isTokenValid(jwt, userDetails)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+                    authToken.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request)
+                    );
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+        }catch(JwtException | UsernameNotFoundException exception){
+            log.error("JwtAuthentication Authentication Exception Occurs! - {}",exception.getClass());
         }
+
         filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
security 설정에서 permitAll()은 `필터체인을 거친 후` 인증정보가 없어도 api 호출이 가능케 하는 것이었다. 
그렇기에 회원가입과 같이 허용이 되었어도 authorization 헤더가 있거나 이상한 값이 들어있으면 에러를 throw 하고 있었다. 
그래서 filter 에서 throw 한 에러를 catch 블록으로 일단 잡아서 클라이언트에게 문제가 없도록 하였다. 
추후 리팩토링이 필요해 보임.

This closes #57 