### PR TITLE
리팩토링 - JwtAuthenticationFilter 에서 검증을 거치지 않을 요청 검사하기

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
@@ -2,8 +2,6 @@ package com.bodytok.healthdiary.config.security;
 
 
 import com.bodytok.healthdiary.filter.jwt.JwtAuthenticationFilter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -12,7 +10,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -67,7 +64,7 @@ public class SecurityConfig {
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true); // 클라이언트가 쿠키를 전송할 수 있도록 허용
-        config.addAllowedOrigin("http://localhost:3000"); // 모든 출처를 허용 (실제 배포 시에는 필요한 출처만 허용해야 함)
+        config.addAllowedOrigin("http://localhost:3000"); // 특정 출처 허용
         config.addAllowedHeader("*"); // 모든 헤더 허용
         config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
 

--- a/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtAuthenticationFilter.java
@@ -9,16 +9,20 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @Slf4j
 @Component
@@ -27,6 +31,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
+
+    private final AntPathRequestMatcher[] permitAllMatchers = {
+            new AntPathRequestMatcher("/auth/sign-up", HttpMethod.POST.name()),
+            new AntPathRequestMatcher("/auth/login", HttpMethod.POST.name())
+    };
+
 
     @Override
     protected void doFilterInternal(
@@ -39,7 +49,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String jwt;
         final String userEmail;
 
+
         try{
+            log.info("요청 정보\n->{}\n->{}",request.getMethod(),request.getRequestURI());
+            if(isPermitAllRequest(request)){ // jwt 인증이 필요없는 요청 검증 없이 넘기기
+                filterChain.doFilter(request, response);
+                return;
+            }
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {
                 filterChain.doFilter(request, response);
                 return;
@@ -66,5 +82,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isPermitAllRequest(HttpServletRequest request) {
+        return Arrays.stream(permitAllMatchers)
+                .anyMatch(matcher -> matcher.matches(request));
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final AntPathRequestMatcher[] permitAllMatchers = {
             new AntPathRequestMatcher("/auth/sign-up", HttpMethod.POST.name()),
-            new AntPathRequestMatcher("/auth/login", HttpMethod.POST.name())
+            new AntPathRequestMatcher("/auth/login", HttpMethod.POST.name()),
+            new AntPathRequestMatcher("/diaries", HttpMethod.GET.name())
     };
 
 


### PR DESCRIPTION
jwtfilter 에서 예외를 붙잡아도 좋지만, 특정 요청 url 에 대해 jwt 를 검증하지 않는 방식이 더 좋을 것 같아 추가해보았음.

This closes #60 