### PR TITLE
유저 인증 기반 다이어리 가져오기

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -91,6 +92,18 @@ public class PersonalExerciseDiaryController {
             @ParameterObject @PageableDefault(sort = "createdAt") Pageable pageable
             ){
         Page<DiaryWithCommentDto> diaries = diaryService.getDiaryWithCommentsADay(date, pageable);
+        return ResponseEntity.ok().body(
+                diaries.map(DiaryWithCommentResponse::from)
+        );
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "다이어리 조회 - 유저 인증 기반")
+    public ResponseEntity<Page<DiaryWithCommentResponse>> getDiariesWithCommentsByUserId(
+            @ParameterObject @PageableDefault(sort = "createdAt",direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        var diaries = diaryService.getDiaryWithCommentsByUserId(userDetails.getId(), pageable);
         return ResponseEntity.ok().body(
                 diaries.map(DiaryWithCommentResponse::from)
         );

--- a/src/main/java/com/bodytok/healthdiary/repository/PersonalExerciseDiaryRepository.java
+++ b/src/main/java/com/bodytok/healthdiary/repository/PersonalExerciseDiaryRepository.java
@@ -20,7 +20,7 @@ public interface PersonalExerciseDiaryRepository extends
     //TODO : 모든 검색을 Containing 으로 하고 있으므로, 인덱스 사용 문제가 야기될 수 있다. 튜닝필요
     Page<PersonalExerciseDiary> findByTitleContaining(String title, Pageable pageable);
     Page<PersonalExerciseDiary> findByContentContaining(String content, Pageable pageable);
-    Page<PersonalExerciseDiary> findByUserAccount_IdContaining(String userId, Pageable pageable);
+    Page<PersonalExerciseDiary> findByUserAccount_Id(Long Id, Pageable pageable);
     Page<PersonalExerciseDiary> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<PersonalExerciseDiary> findByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
 

--- a/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
@@ -56,6 +56,14 @@ public class PersonalExerciseDiaryService {
         return DiaryWithCommentDto.from(diary);
     }
 
+    //다이어리 조회 - 유저 인증 기반
+    @Transactional(readOnly = true)
+    public Page<DiaryWithCommentDto> getDiaryWithCommentsByUserId(Long userId, Pageable pageable){
+        var diaries = diaryRepository.findByUserAccount_Id(userId, pageable);
+        return diaries.map(DiaryWithCommentDto::from);
+
+    }
+
     @Transactional(readOnly = true)
     public Page<DiaryWithCommentDto> getDiaryWithCommentsADay(String date, Pageable pageable) {
         // "yyyy-mm-dd" 형식의 문자열을 LocalDateTime으로 변환


### PR DESCRIPTION
인증된 유저의 id 로 다이어리를 가져오는 api 를 작성하였음.

**개선점** :  기존의 있던 /search 의 쿼리 인자로 받아서 유저id로 다이어리를 검색하는 것으로 통합시켜도 될 것 같음.