### PR TITLE
다이어리 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -135,6 +134,16 @@ public class PersonalExerciseDiaryController {
             @PathVariable(name = "diaryId") Long diaryId
     ) {
         diaryService.deleteDiary(diaryId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{diaryId}/like")
+    @Operation(summary = "다이어리 좋아요")
+    public ResponseEntity<Void> likeDiary(
+            @PathVariable(name = "diaryId") Long diaryId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        diaryService.likeDiary(diaryId, userDetails.getId());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/bodytok/healthdiary/domain/DiaryLike.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/DiaryLike.java
@@ -12,8 +12,6 @@ import java.util.Objects;
 @ToString(callSuper = true)
 @Table(indexes = {
         @Index(columnList = "createdAt"),
-//        @Index(columnList = "user_id"),
-//        @Index(columnList = "diary_id") -> 추후 쿼리 작성 시 고려
 })
 @Entity
 public class DiaryLike extends AuditingFields {
@@ -23,11 +21,11 @@ public class DiaryLike extends AuditingFields {
     @Column(name = "like_id")
     private Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserAccount userAccount;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", nullable = false)
     private PersonalExerciseDiary personalExerciseDiary;
 

--- a/src/main/java/com/bodytok/healthdiary/domain/PersonalExerciseDiary.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/PersonalExerciseDiary.java
@@ -58,7 +58,7 @@ public class PersonalExerciseDiary extends AuditingFields {
 
     // 좋아요 필드 추가
     @ToString.Exclude
-    @OneToMany(mappedBy = "personalExerciseDiary", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "personalExerciseDiary", cascade = CascadeType.ALL, orphanRemoval = true)
     private  Set<DiaryLike> likes = new LinkedHashSet<>();
 
     protected PersonalExerciseDiary() {
@@ -94,6 +94,13 @@ public class PersonalExerciseDiary extends AuditingFields {
                 return;
             }
         }
+    }
+
+    public void addLike(DiaryLike like) {
+        likes.add(like);
+    }
+    public void removeLike(DiaryLike like){
+        likes.remove(like);
     }
 
 


### PR DESCRIPTION
DiaryLike 의 레포지토리를 참조하지않고, 다이어리 도메인에 양뱡향 매핑을 하여 쉽게 좋아요를 저장하고, 삭제할 수 있도록 만들었음.
This closes #74 