### PR TITLE
#78 - 다이어리 업데이트 및 삭제 시 소유권 확인

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -131,9 +131,10 @@ public class PersonalExerciseDiaryController {
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "다이어리 삭제")
     public ResponseEntity<Void> deleteDiary(
-            @PathVariable(name = "diaryId") Long diaryId
+            @PathVariable(name = "diaryId") Long diaryId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        diaryService.deleteDiary(diaryId);
+        diaryService.deleteDiary(diaryId, userDetails);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/bodytok/healthdiary/exepction/GlobalExceptionHandler.java
+++ b/src/main/java/com/bodytok/healthdiary/exepction/GlobalExceptionHandler.java
@@ -1,11 +1,11 @@
 package com.bodytok.healthdiary.exepction;
 
 
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -58,6 +58,19 @@ public class GlobalExceptionHandler {
         CommonApiError apiError = new CommonApiError(
                 request.getRequestURI(),
                 message,
+                HttpStatus.UNAUTHORIZED.value(),
+                LocalDateTime.now()
+        );
+        return new ResponseEntity<>(apiError, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CommonApiError> handleAccessDeniedException(
+            AccessDeniedException ex,
+            HttpServletRequest request) {
+        CommonApiError apiError = new CommonApiError(
+                request.getRequestURI(),
+                ex.getMessage(),
                 HttpStatus.UNAUTHORIZED.value(),
                 LocalDateTime.now()
         );


### PR DESCRIPTION
업데이트 / 삭제 시 사용자를 jwt 기반의 인증만 생각하고 소유권에 대한 생각은 하지 못했다.
보안 강화를 위해 서비스 코드에 다이어리의 소유자를 체크하는 간단한 로직을 추가하였다.

* accessDenied 에 대한 예외처리 추가

This closes  #78 