### PR TITLE
리팩토링 : jwt 만료 에러 클라이언트에게 알려주기

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/CustomAuthenticationEntryPoint.java
@@ -21,5 +21,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             AuthenticationException authException
     ) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader("AuthenticationFailed","true");
     }
 }


### PR DESCRIPTION
`authenticationFailed` 커스텀 헤더가 `true` 일 때, 클라이언트에서 refreshToken 으로 재발급 요청을 자동으로 수행하기 위함.


This closes #87 