### PR TITLE
좋아요 수 다이어리 response dto에 포함하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ repositories {
 }
 
 dependencies {
+	// aws sdk
+	implementation(platform("software.amazon.awssdk:bom:2.25.22"))
+	implementation("software.amazon.awssdk:s3")
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/bodytok/healthdiary/controller/ImageController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/ImageController.java
@@ -1,0 +1,37 @@
+package com.bodytok.healthdiary.controller;
+
+
+import com.bodytok.healthdiary.dto.diaryImage.DiaryImageDto;
+import com.bodytok.healthdiary.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/images")
+@Tag(name ="Image")
+public class ImageController {
+
+    private final ImageService imageService;
+
+
+    @PostMapping(value = "/upload",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(summary = "이미지 저장", description = "이미지 File 을 저장 - MultipartFile")
+    @ApiResponse(responseCode = "200", description = "이미지 업로드 완료 후, 이미지 ID를 반환함")
+    public Long uploadImage(
+            @RequestParam("file") MultipartFile file
+    ) {
+        return imageService.storeImage(file);
+    }
+
+}

--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -136,12 +136,12 @@ public class PersonalExerciseDiaryController {
 
     @PostMapping("/{diaryId}/like")
     @Operation(summary = "다이어리 좋아요")
-    public ResponseEntity<Void> likeDiary(
+    public ResponseEntity<Integer> likeDiary(
             @PathVariable(name = "diaryId") Long diaryId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        diaryService.likeDiary(diaryId, userDetails.getId());
-        return ResponseEntity.ok().build();
+        int like_count = diaryService.likeDiary(diaryId, userDetails.getId());
+        return ResponseEntity.ok().body(like_count);
     }
 
 }

--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -59,7 +59,8 @@ public class PersonalExerciseDiaryController {
 
         DiaryDto diary = diaryService.saveDiaryWithHashtags(
                 request.toDto(userDetails.toDto()),
-                hashtags
+                hashtags,
+                request.imageIds()
         );
         DiaryResponse diaryResponse = DiaryResponse.from(diary);
 

--- a/src/main/java/com/bodytok/healthdiary/domain/DiaryImage.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/DiaryImage.java
@@ -1,0 +1,46 @@
+package com.bodytok.healthdiary.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+@Getter
+@Entity
+public class DiaryImage extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false, unique = true)
+    private String savedFileName;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private PersonalExerciseDiary personalExerciseDiary;
+
+
+    protected DiaryImage(){}
+
+    private DiaryImage(String originalFileName, String savedFileName, String filePath){
+        this.originalFileName = originalFileName;
+        this.savedFileName = savedFileName;
+        this.filePath = filePath;
+    }
+
+    public static DiaryImage of(String originalFileName, String savedFileName, String filePath){
+        return new DiaryImage(originalFileName, savedFileName, filePath);
+    }
+
+}

--- a/src/main/java/com/bodytok/healthdiary/domain/DiaryLike.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/DiaryLike.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 
 
 @Getter
-@ToString(callSuper = true)
 @Table(indexes = {
         @Index(columnList = "createdAt"),
 })

--- a/src/main/java/com/bodytok/healthdiary/domain/PersonalExerciseDiary.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/PersonalExerciseDiary.java
@@ -61,6 +61,20 @@ public class PersonalExerciseDiary extends AuditingFields {
     @OneToMany(mappedBy = "personalExerciseDiary", cascade = CascadeType.ALL, orphanRemoval = true)
     private  Set<DiaryLike> likes = new LinkedHashSet<>();
 
+    @ToString.Exclude
+    @OneToMany(mappedBy = "personalExerciseDiary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<DiaryImage> diaryImages = new HashSet<>();
+
+    public void addDiaryImage(DiaryImage diaryImage) {
+        diaryImages.add(diaryImage);
+        diaryImage.setPersonalExerciseDiary(this);
+    }
+
+    public void removeDiaryImage(DiaryImage diaryImage) {
+        diaryImages.remove(diaryImage);
+        diaryImage.setPersonalExerciseDiary(null);
+    }
+
     protected PersonalExerciseDiary() {
     }
 

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryWithCommentDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryWithCommentDto.java
@@ -21,14 +21,16 @@ public record DiaryWithCommentDto(
         Boolean isPublic,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt,
-        Set<HashtagDto> hashtagDtoSet
+        Set<HashtagDto> hashtagDtoSet,
+
+        Integer likeCount
 ) {
 
     public static DiaryWithCommentDto of(Long id, UserAccountDto userAccountDto, Set<CommentDto> commentDtoSet, String title, String content, Integer totalExTime, Boolean isPublic, LocalDateTime createdAt, LocalDateTime modifiedAt) {
-        return new DiaryWithCommentDto(id, userAccountDto, commentDtoSet, title, content, totalExTime, isPublic, createdAt, modifiedAt, Set.of());
+        return new DiaryWithCommentDto(id, userAccountDto, commentDtoSet, title, content, totalExTime, isPublic, createdAt, modifiedAt, Set.of(),null);
     }
-    public static DiaryWithCommentDto of(Long id, UserAccountDto userAccountDto, Set<CommentDto> commentDtoSet, String title, String content, Integer totalExTime, Boolean isPublic, LocalDateTime createdAt, LocalDateTime modifiedAt,  Set<HashtagDto> hashtagDtoSet) {
-        return new DiaryWithCommentDto(id, userAccountDto, commentDtoSet, title, content, totalExTime, isPublic, createdAt, modifiedAt, hashtagDtoSet);
+    public static DiaryWithCommentDto of(Long id, UserAccountDto userAccountDto, Set<CommentDto> commentDtoSet, String title, String content, Integer totalExTime, Boolean isPublic, LocalDateTime createdAt, LocalDateTime modifiedAt,  Set<HashtagDto> hashtagDtoSet, Integer likeCount) {
+        return new DiaryWithCommentDto(id, userAccountDto, commentDtoSet, title, content, totalExTime, isPublic, createdAt, modifiedAt, hashtagDtoSet, likeCount);
     }
 
     public static DiaryWithCommentDto from(PersonalExerciseDiary entity) {
@@ -47,7 +49,8 @@ public record DiaryWithCommentDto(
                 entity.getDiaryHashtags().stream()
                         .map(PersonalExerciseDiaryHashtag::getHashtag)
                         .map(HashtagDto::from)
-                        .collect(Collectors.toUnmodifiableSet())
+                        .collect(Collectors.toUnmodifiableSet()),
+                entity.getLikes().size()
         );
     }
 

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/request/DiaryRequest.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/request/DiaryRequest.java
@@ -15,10 +15,13 @@ public record DiaryRequest(
     @Schema(description = "커뮤니티 공개 여부", nullable = false, example = "false")
     Boolean isPublic,
     @Schema(description = "해시태그", nullable = true)
-    Set<String> hashtags
+    Set<String> hashtags,
+
+    @Schema(description = "이미지 아이디", nullable = true)
+    Set<Long> imageIds
 ) {
-    public static DiaryRequest of(String title, String content, Boolean isPublic, Set<String> hashtags) {
-        return new DiaryRequest(title,content,isPublic, hashtags);
+    public static DiaryRequest of(String title, String content, Boolean isPublic, Set<String> hashtags,Set<Long> imageIds ) {
+        return new DiaryRequest(title,content,isPublic, hashtags, imageIds);
     }
 
     public DiaryDto toDto(UserAccountDto userAccountDto) {

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryWithCommentResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryWithCommentResponse.java
@@ -20,12 +20,12 @@ public record DiaryWithCommentResponse(
         String email,
         String nickname,
         Set<HashtagDto> hashtags,
-        Set<CommentResponse> comments
+        Set<CommentResponse> comments,
+        Integer likeCount
 ) {
 
-    public static DiaryWithCommentResponse of(Long id, String title, String content, Boolean isPublic, Integer totalExTime, LocalDateTime createAt,Long userId, String email, String nickname, Set<HashtagDto> hashtags, Set<CommentResponse> comments){
-        return new DiaryWithCommentResponse(id, title, content, isPublic, totalExTime, createAt, userId, email, nickname, hashtags, comments);
-
+    public static DiaryWithCommentResponse of(Long id, String title, String content, Boolean isPublic, Integer totalExTime, LocalDateTime createAt,Long userId, String email, String nickname, Set<HashtagDto> hashtags, Set<CommentResponse> comments, Integer likeCount){
+        return new DiaryWithCommentResponse(id, title, content, isPublic, totalExTime, createAt, userId, email, nickname, hashtags, comments, null);
     }
 
     public static DiaryWithCommentResponse from(DiaryWithCommentDto dto) {
@@ -48,8 +48,8 @@ public record DiaryWithCommentResponse(
                         .collect(Collectors.toUnmodifiableSet()),
                 dto.commentDtoSet().stream()
                         .map(CommentResponse::from)
-                        .collect(Collectors.toCollection(LinkedHashSet::new))
-
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                dto.likeCount()
         );
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/dto/diaryImage/DiaryImageDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diaryImage/DiaryImageDto.java
@@ -1,0 +1,38 @@
+package com.bodytok.healthdiary.dto.diaryImage;
+
+import com.bodytok.healthdiary.domain.DiaryImage;
+import com.bodytok.healthdiary.domain.PersonalExerciseDiary;
+
+
+public record DiaryImageDto(
+         Long id,
+
+         String originalFileName,
+
+         String savedFileName,
+
+         String filePath,
+
+         PersonalExerciseDiary personalExerciseDiary
+) {
+
+    public static DiaryImageDto of(Long id,String originalFileName, String savedFileName, String filePath, PersonalExerciseDiary personalExerciseDiary){
+        return new DiaryImageDto(id, originalFileName,savedFileName,filePath, null);
+    }
+
+    public static DiaryImageDto of(String originalFileName, String savedFileName, String filePath){
+        return new DiaryImageDto(null, originalFileName,savedFileName,filePath,null);
+    }
+
+
+    public static DiaryImageDto from(DiaryImage entity){
+        return of(
+                entity.getId(),
+                entity.getOriginalFileName(),
+                entity.getSavedFileName(),
+                entity.getFilePath(),
+                null
+        );
+    }
+
+}

--- a/src/main/java/com/bodytok/healthdiary/repository/DiaryImageRepository.java
+++ b/src/main/java/com/bodytok/healthdiary/repository/DiaryImageRepository.java
@@ -1,0 +1,11 @@
+package com.bodytok.healthdiary.repository;
+
+import com.bodytok.healthdiary.domain.DiaryImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryImageRepository extends
+        JpaRepository<DiaryImage, Long> {
+
+
+
+}

--- a/src/main/java/com/bodytok/healthdiary/service/ImageService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/ImageService.java
@@ -1,0 +1,69 @@
+package com.bodytok.healthdiary.service;
+
+import com.bodytok.healthdiary.domain.DiaryImage;
+import com.bodytok.healthdiary.repository.DiaryImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final DiaryImageRepository diaryImageRepository;
+
+    @Value("${file.uploadDir}")
+    private String uploadDir;
+
+    public Long storeImage(MultipartFile file) {
+        String originalFileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
+        String fileNameWithoutExtension = StringUtils.stripFilenameExtension(originalFileName);
+        String extension = StringUtils.getFilenameExtension(originalFileName);
+        String savedFileName = fileNameWithoutExtension + "_" + UUID.randomUUID() + "." + extension;
+
+        log.info("savedFileName : {}", savedFileName);
+
+        try {
+            Path uploadPath = Paths.get(uploadDir);
+            if (!Files.exists(uploadPath)) {
+                Files.createDirectories(uploadPath);
+            }
+
+            Path filePath = uploadPath.resolve(savedFileName);
+            Files.copy(file.getInputStream(), filePath);
+
+            DiaryImage diaryImage = DiaryImage.of(originalFileName,savedFileName,filePath.toString());
+
+            DiaryImage savedImage = diaryImageRepository.save(diaryImage);
+
+            return savedImage.getId();
+        } catch (IOException ex) {
+            throw new RuntimeException("Failed to store image " + originalFileName + ". Please try again!", ex);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Set<DiaryImage> getImages(Set<Long> imageIds){
+        return imageIds.stream()
+                .map(diaryImageRepository::findById)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
@@ -11,7 +11,6 @@ import com.bodytok.healthdiary.repository.*;
 import com.bodytok.healthdiary.util.DateConverter;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +33,7 @@ public class PersonalExerciseDiaryService {
     private final PersonalExerciseDiaryHashtagRepository diaryHashtagRepository;
     private final UserAccountRepository userAccountRepository;
     private final HashtagService hashtagService;
+    private final ImageService imageService;
 
 
     //다이어리 조회 - 댓글 포함
@@ -88,12 +88,13 @@ public class PersonalExerciseDiaryService {
 
 
     //다이어리 저장
-    public DiaryDto saveDiaryWithHashtags(DiaryDto dto, Set<HashtagDto> hashtagDtoSet) {
+    public DiaryDto saveDiaryWithHashtags(DiaryDto dto, Set<HashtagDto> hashtagDtoSet, Set<Long> imageIds) {
 
         try {
             // Dto -> Entity
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().id());
             PersonalExerciseDiary diary = dto.toEntity(userAccount);
+            Set<DiaryImage> diaryImageSet = imageService.getImages(imageIds);
 
             diary = diaryRepository.save(diary);
 
@@ -103,6 +104,14 @@ public class PersonalExerciseDiaryService {
                     diary.addHashtag(hashtag);
                 }
             }
+
+            if(!diaryImageSet.isEmpty()){
+                for (DiaryImage diaryImage : diaryImageSet){
+                    diary.addDiaryImage(diaryImage);
+                }
+            }
+            
+
             return DiaryDto.from(diary);
 
         } catch (DataAccessException e) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ logging:
     org.springframework.web.servlet: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
 
+file:
+  uploadDir: src/main/resources/diary/images
 
 spring:
   datasource:


### PR DESCRIPTION
다이어리에는 단순히 좋아요 수만 간단히 리턴해주는 걸로 일단 완료함.

다이어리 - 좋아요 연관관계 매핑 시 양방향 매핑을 제거하는 것도 고려해보는 게 좋을듯

This closes #92 