### PR TITLE
이미지 저장 로직 구현 - fix :  이미지 업로드 경로 변경

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/config/WebConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/WebConfig.java
@@ -11,10 +11,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
 
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")
-                .addResourceLocations("classpath:/static/images/")
+                .addResourceLocations("file:volumes/")
                 .setCacheControl(CacheControl.noCache()); // 캐시 무효화
 
     }

--- a/src/main/java/com/bodytok/healthdiary/controller/ImageController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/ImageController.java
@@ -1,12 +1,12 @@
 package com.bodytok.healthdiary.controller;
 
 
+import com.bodytok.healthdiary.dto.ImageUploadResponse;
 import com.bodytok.healthdiary.service.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,7 +24,7 @@ public class ImageController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "이미지 저장", description = "이미지 File 을 저장 - MultipartFile")
     @ApiResponse(responseCode = "200", description = "이미지 업로드 완료 후, 이미지 ID를 반환함")
-    public Long uploadImage(
+    public ImageUploadResponse uploadImage(
             @RequestParam("file") MultipartFile file
     ) {
         return imageService.storeImage(file);

--- a/src/main/java/com/bodytok/healthdiary/dto/ImageUploadResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/ImageUploadResponse.java
@@ -1,0 +1,12 @@
+package com.bodytok.healthdiary.dto;
+
+
+public record ImageUploadResponse(
+        Long imageId,
+        String url
+) {
+
+    public static ImageUploadResponse of(Long imageId, String url){
+        return new ImageUploadResponse(imageId, url);
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryDto.java
@@ -26,7 +26,7 @@ public record DiaryDto(
         LocalDateTime createdAt,
         LocalDateTime modifiedAt,
         Set<HashtagDto> hashtagDtoSet,
-        List<DiaryImageDto> diaryImageDtoList
+        List<String> imageUrls
 
 ) {
 
@@ -49,7 +49,7 @@ public record DiaryDto(
                         .map(HashtagDto::from)
                         .collect(Collectors.toUnmodifiableSet()),
                 entity.getDiaryImages().stream()
-                        .map(DiaryImageDto::from)
+                        .map(diaryImage -> "http://localhost:8080/images/".concat(diaryImage.getSavedFileName()))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryWithCommentDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/DiaryWithCommentDto.java
@@ -27,7 +27,7 @@ public record DiaryWithCommentDto(
         Set<HashtagDto> hashtagDtoSet,
         Integer likeCount,
 
-        List<String> ImageUrls
+        List<String> imageUrls
 ) {
 
     public static DiaryWithCommentDto of(Long id, UserAccountDto userAccountDto, Set<CommentDto> commentDtoSet, String title, String content, Integer totalExTime, Boolean isPublic, LocalDateTime createdAt, LocalDateTime modifiedAt) {

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryResponse.java
@@ -2,11 +2,13 @@ package com.bodytok.healthdiary.dto.diary.response;
 
 import com.bodytok.healthdiary.dto.diary.DiaryDto;
 import com.bodytok.healthdiary.dto.diaryImage.DiaryImageDto;
+import com.bodytok.healthdiary.dto.diaryImage.DiaryImageResponse;
 import com.bodytok.healthdiary.dto.hashtag.HashtagDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public record DiaryResponse(
         Long id,
@@ -19,7 +21,7 @@ public record DiaryResponse(
         String email,
         String nickname,
         Set<HashtagDto> hashtags,
-        List<DiaryImageDto>  images
+        List<String> imageUrls
 
 ) {
 
@@ -45,7 +47,7 @@ public record DiaryResponse(
                 dto.userAccountDto().email(),
                 nickname,
                 dto.hashtagDtoSet(),
-                dto.diaryImageDtoList()
+                dto.imageUrls()
         );
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryWithCommentResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diary/response/DiaryWithCommentResponse.java
@@ -53,7 +53,7 @@ public record DiaryWithCommentResponse(
                         .map(CommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
                 dto.likeCount(),
-                dto.ImageUrls()
+                dto.imageUrls()
         );
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/dto/diaryImage/DiaryImageResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/diaryImage/DiaryImageResponse.java
@@ -1,0 +1,20 @@
+package com.bodytok.healthdiary.dto.diaryImage;
+
+public record DiaryImageResponse(
+        Long id,
+
+        String originalFileName,
+
+        String savedFileName
+
+) {
+
+    public static DiaryImageResponse from(DiaryImageDto dto){
+        return new DiaryImageResponse(
+                dto.id(),
+                dto.originalFileName(),
+                dto.savedFileName()
+        );
+    }
+
+}

--- a/src/main/java/com/bodytok/healthdiary/service/ImageService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/ImageService.java
@@ -1,6 +1,7 @@
 package com.bodytok.healthdiary.service;
 
 import com.bodytok.healthdiary.domain.DiaryImage;
+import com.bodytok.healthdiary.dto.ImageUploadResponse;
 import com.bodytok.healthdiary.repository.DiaryImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +29,7 @@ public class ImageService {
     @Value("${file.uploadDir}")
     private String uploadDir;
 
-    public Long storeImage(MultipartFile file) {
+    public ImageUploadResponse storeImage(MultipartFile file) {
         String originalFileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
         String fileNameWithoutExtension = StringUtils.stripFilenameExtension(originalFileName);
         String extension = StringUtils.getFilenameExtension(originalFileName);
@@ -49,7 +50,8 @@ public class ImageService {
 
             DiaryImage savedImage = diaryImageRepository.save(diaryImage);
 
-            return savedImage.getId();
+
+            return ImageUploadResponse.of(savedImage.getId(), "http://localhost:8080/images/"+savedFileName);
         } catch (IOException ex) {
             throw new RuntimeException("이미지 저장 실패 :" + originalFileName, ex);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 file:
-  uploadDir: src/main/resources/static/images
+  uploadDir: ${user.dir}/volumes
   url: http://localhost:8080/images/
 
 spring:


### PR DESCRIPTION

* 리소스플더가 캐싱 되는 문제로, 이미지 업로드 폴더 변경
* 이미지 업로드 response & 다이어리 반환 시 이미지의 다이어리 정보 제외