### PR TITLE
다이어리 수정 시 이미지 관련 기능 추가

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/ImageController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/ImageController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -45,6 +46,15 @@ public class ImageController {
             @RequestParam("file") MultipartFile file) throws IOException
     {
         return s3Service.uploadImage(file);
+    }
+
+
+    @DeleteMapping("/{imageId}")
+    public ResponseEntity<Void> remove(
+            @PathVariable(name = "imageId") Long imageId
+    ){
+        imageService.deleteImage(imageId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -105,7 +105,7 @@ public class PersonalExerciseDiaryController {
     }
 
     @PutMapping("/{diaryId}")
-    @Operation(summary = "다이어리 수정")
+    @Operation(summary = "다이어리 수정 - 이미지 먼저 저장 or 삭제 후 진행")
     public ResponseEntity<Void> updateDiary(
             @PathVariable(name = "diaryId") Long diaryId,
             @RequestBody DiaryRequest request,
@@ -119,7 +119,9 @@ public class PersonalExerciseDiaryController {
         diaryService.updateDiary(
                 diaryId,
                 request.toDto(userDetails.toDto()),
-                hashtags
+                hashtags,
+                request.imageIds()
+
         );
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/bodytok/healthdiary/util/FileNameConverter.java
+++ b/src/main/java/com/bodytok/healthdiary/util/FileNameConverter.java
@@ -1,0 +1,21 @@
+package com.bodytok.healthdiary.util;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Component
+@NoArgsConstructor
+public class FileNameConverter {
+
+    public String convertFileName(MultipartFile file){
+        String originalFileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
+        String fileNameWithoutExtension = StringUtils.stripFilenameExtension(originalFileName);
+        String extension = StringUtils.getFilenameExtension(originalFileName);
+        return fileNameWithoutExtension + "_" + UUID.randomUUID() + "." + extension;
+    }
+}


### PR DESCRIPTION
* 이미지 추가 시, 다이어리 저장할 때 새로운 이미지만 매핑하여 저장
* 이미지 삭제 시, 이미지 서비스에서 삭제되게 함.
* S3Service <-> ImageService  순환참조 문제로 기존에 imageSerivce에 있던 기능을 FileNameConverter 클래스로 작성하여  주입받아 사용

This closes #98 