### PR TITLE
리팩토링 : jwt 로그인, 리프레시 기능 수정

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/config/JpaConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/JpaConfig.java
@@ -23,7 +23,12 @@ public class JpaConfig {
                 .map(SecurityContext::getAuthentication)
                 .filter(Authentication::isAuthenticated)
                 .map(Authentication::getPrincipal)
-                .map(CustomUserDetails.class::cast)
-                .map(CustomUserDetails::getUsername);
+                .map(principal -> {
+                    if (principal instanceof CustomUserDetails) {
+                        return ((CustomUserDetails) principal).getNickname();
+                    } else {
+                        return "Unknown";
+                    }
+                });
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/CustomAuthenticationEntryPoint.java
@@ -21,6 +21,5 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             AuthenticationException authException
     ) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setHeader("AuthenticationFailed","true");
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.bodytok.healthdiary.config.security;
 
 
 import com.bodytok.healthdiary.filter.jwt.JwtAuthenticationFilter;
+import com.bodytok.healthdiary.filter.jwt.JwtExceptionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -20,11 +21,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
     private final AuthenticationProvider authenticationProvider;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthFilter, AuthenticationProvider authenticationProvider, CustomAuthenticationEntryPoint authenticationEntryPoint) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthFilter,JwtExceptionFilter jwtExceptionFilter, AuthenticationProvider authenticationProvider, CustomAuthenticationEntryPoint authenticationEntryPoint) {
         this.jwtAuthFilter = jwtAuthFilter;
+        this.jwtExceptionFilter = jwtExceptionFilter;
         this.authenticationProvider = authenticationProvider;
         this.authenticationEntryPoint = authenticationEntryPoint;
     }
@@ -53,9 +57,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         auth -> auth
                                 .requestMatchers("auth/**").permitAll()
-                                .requestMatchers(HttpMethod.GET,"diaries/{diaryId}").permitAll()
                                 .requestMatchers(HttpMethod.GET,"images/**").permitAll() //정적리소스 이미지 경로
                                 .requestMatchers(HttpMethod.GET, "community/**").permitAll() //커뮤니티 다이어리 가져오기
+                                .requestMatchers(HttpMethod.GET, "diaries/my").authenticated()
+                                .requestMatchers(HttpMethod.GET,"diaries/{diaryId}").permitAll()
                                 .anyRequest().authenticated()
                 )
                 //Authentication Entry Point -> Exception Handler
@@ -68,6 +73,7 @@ public class SecurityConfig {
                 )
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/bodytok/healthdiary/domain/constant/ErrorMessage.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/constant/ErrorMessage.java
@@ -1,0 +1,34 @@
+package com.bodytok.healthdiary.domain.constant;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public enum ErrorMessage {
+    WRONG_TYPE_TOKEN(400, "잘못된 토큰 타입입니다."),
+    UNSUPPORTED_TOKEN(400, "지원되지 않는 토큰입니다."),
+    EXPIRED_TOKEN(401, "만료된 토큰입니다."),
+    UNKNOWN_ERROR(500, "알 수 없는 오류가 발생했습니다."),
+    ACCESS_DENIED(403, "접근 불가한 요청입니다.");
+
+    private final int code;
+    private final String msg;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    ErrorMessage(int code, String msg) {
+        this.code = code;
+        this.msg = msg;
+    }
+
+    public String toJsonString() {
+        try {
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/bodytok/healthdiary/filter/jwt/JwtExceptionFilter.java
@@ -1,0 +1,54 @@
+package com.bodytok.healthdiary.filter.jwt;
+
+import com.bodytok.healthdiary.domain.constant.ErrorMessage;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        try {
+            //JwtAuthenticationFilter로
+            chain.doFilter(request, response);
+        } catch (JwtException ex) {
+            String message = ex.getMessage();
+            if(ErrorMessage.UNKNOWN_ERROR.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.UNKNOWN_ERROR);
+            }
+            //잘못된 타입의 토큰인 경우
+            else if(ErrorMessage.WRONG_TYPE_TOKEN.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.WRONG_TYPE_TOKEN);
+            }
+            //토큰 만료된 경우
+            else if(ErrorMessage.EXPIRED_TOKEN.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.EXPIRED_TOKEN);
+            }
+            //지원되지 않는 토큰인 경우
+            else if(ErrorMessage.UNSUPPORTED_TOKEN.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.UNSUPPORTED_TOKEN);
+            }
+            else {
+                setResponse(response, ErrorMessage.ACCESS_DENIED);
+            }
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorMessage errorMessage) throws RuntimeException, IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorMessage.getCode());
+        response.getWriter().print(errorMessage.toJsonString());
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/service/jwt/JwtService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/jwt/JwtService.java
@@ -18,7 +18,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
-import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
jwt 를 통한 로그인, 리프레시 기능을 수정하였음.

* jwt filter 에서 발생하는 관련 에러를 `ErrorMessage`  enum 으로 작성하여 클라이언트에게 반환하도록 수정함.
*  **jwtAuthenticationFilter 앞에 JwtExceptionFilter 를 또 filter 로 두어 error 를 처리할 수 있게 되었음.**

This closes #97 