### PR TITLE
 AuthenticationEntiryPoint 에러 반환 json 으로 보내주기

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.bodytok.healthdiary.config.security;
 
 
+import com.bodytok.healthdiary.domain.constant.ErrorMessage;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,6 +21,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException, ServletException {
+
+        response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().print(ErrorMessage.UNAUTHORIZED.toJsonString());
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/domain/constant/ErrorMessage.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/constant/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
     WRONG_TYPE_TOKEN(400, "WRONG_TYPE_TOKEN", "잘못된 토큰 타입입니다."),
     UNSUPPORTED_TOKEN(400, "UNSUPPORTED_TOKEN", "지원되지 않는 토큰입니다."),
     EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
+    UNAUTHORIZED(401, "UNAUTHORIZED","인증이 필요합니다."),
     UNKNOWN_ERROR(500, "UNKNOWN_ERROR", "알 수 없는 오류가 발생했습니다."),
     ACCESS_DENIED(403, "ACCESS_DENIED", "접근 불가한 요청입니다.");
 


### PR DESCRIPTION
JwtAuthenticationFilter 에서 발생한 401 auth 에러는  CustomAuthenticationEntiryPoint 에서 그 내용을 반환하기 때문에
클라이언트에서 내용을 쉽게 알 수 있도록 json 으로 매핑하여 반환하도록 수정함.

This closes #114 