### PR TITLE
Fix - 다이어리 가져오기 수정

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/PersonalExerciseDiaryController.java
@@ -113,9 +113,10 @@ public class PersonalExerciseDiaryController {
             @Content(mediaType = "application/json", schema = @Schema(implementation = CommonApiError.class))
     })
     public ResponseEntity<DiaryWithCommentResponse> getDiaryWithComments(
-            @PathVariable(name = "diaryId") Long diaryId
+            @PathVariable(name = "diaryId") Long diaryId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        DiaryWithCommentDto diary = diaryService.getDiaryWithComments(diaryId);
+        DiaryWithCommentDto diary = diaryService.getDiaryWithComments(diaryId, userDetails);
 
         return ResponseEntity.ok(DiaryWithCommentResponse.from(diary));
     }

--- a/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,11 +44,15 @@ public class PersonalExerciseDiaryService {
 
     //다이어리 조회 - 댓글 포함
     @Transactional(readOnly = true)
-    public DiaryWithCommentDto getDiaryWithComments(Long diaryId) {
+    public DiaryWithCommentDto getDiaryWithComments(Long diaryId, CustomUserDetails userDetails) {
         var diary = diaryRepository.findById(diaryId).orElseThrow(() -> new EntityNotFoundException("다이어리가 없습니다. - diaryId : " + diaryId));
-
-        if (!diary.getIsPublic()) {
-            throw new AccessDeniedException("공개된 다이어리가 아닙니다.");
+        if (!diary.getIsPublic()){
+            if(userDetails == null){
+                throw new AccessDeniedException("공개된 다이어리가 아닙니다.");
+            }
+            else if(!Objects.equals(userDetails.getId(), diary.getUserAccount().getId())) {
+                throw new AccessDeniedException("공개된 다이어리가 아닙니다.");
+            }
         }
 
         return DiaryWithCommentDto.from(diary);


### PR DESCRIPTION
**PROB**
커뮤니티 다이어리 조회와 내 다이어리 조회를 구분하지 않고 하나의 메소드에서 처리하려고 했으나 잊어버리고 isPublic= false 인 것은 에러 처리하고 있었다.

**SOLVED**
인증 여부를 확인하고 소유자인지와 isPubic 모두 확인하는 로직으로 수정함.

This closes #126 