### PR TITLE
#135 - 유저 프로필 정보 조회 API 작성

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/UserController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.bodytok.healthdiary.controller;
+
+
+import com.bodytok.healthdiary.domain.security.CustomUserDetails;
+import com.bodytok.healthdiary.dto.userAccount.UserProfile;
+import com.bodytok.healthdiary.service.UserAccountService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+@Tag(name = "User")
+public class UserController {
+
+    private final UserAccountService userAccountService;
+
+    @GetMapping
+    public UserProfile userProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return userAccountService.getUserProfile(userDetails.getId());
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/dto/userAccount/UserProfile.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/userAccount/UserProfile.java
@@ -1,0 +1,37 @@
+package com.bodytok.healthdiary.dto.userAccount;
+
+
+import com.bodytok.healthdiary.domain.UserAccount;
+import com.bodytok.healthdiary.dto.UserAccountDto;
+
+/**
+ * 유저 id, 닉네임, 이메일
+ * 팔로워 / 팔로잉 count
+ * 커뮤니티 일지 count
+ */
+
+public record UserProfile(
+        Long id,
+        String nickname,
+        String email,
+        Integer followerCount,
+        Integer followingCount,
+        Integer diaryCount
+) {
+
+    public static UserProfile of(Long id, String nickname, String email, Integer followerCount, Integer followingCount, Integer diaryCount){
+        return new UserProfile(id, nickname, email, followerCount, followingCount, diaryCount);
+    }
+
+    public static UserProfile toProfileInfo(UserAccount userAccount, Integer diaryCount){
+        return of(
+                userAccount.getId(),
+                userAccount.getNickname(),
+                userAccount.getEmail(),
+                userAccount.getFollowerList().size(),
+                userAccount.getFollowingList().size(),
+                diaryCount
+        );
+    }
+
+}

--- a/src/main/java/com/bodytok/healthdiary/repository/PersonalExerciseDiaryRepository.java
+++ b/src/main/java/com/bodytok/healthdiary/repository/PersonalExerciseDiaryRepository.java
@@ -32,6 +32,8 @@ public interface PersonalExerciseDiaryRepository extends
     Page<PersonalExerciseDiary> findByUserAccount_Id(Long userId, Pageable pageable);
     Page<PersonalExerciseDiary> findByUserAccount_IdAndCreatedAtBetween(Long userId, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
 
+    int countByUserAccount_Id(Long userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QPersonalExerciseDiary root){
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/PersonalExerciseDiaryService.java
@@ -255,5 +255,8 @@ public class PersonalExerciseDiaryService {
         }
     }
 
+    public Integer getDiaryCount(Long userId){
+        return diaryRepository.countByUserAccount_Id(userId);
+    }
 
 }

--- a/src/main/java/com/bodytok/healthdiary/service/UserAccountService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/UserAccountService.java
@@ -3,6 +3,7 @@ package com.bodytok.healthdiary.service;
 
 import com.bodytok.healthdiary.domain.UserAccount;
 import com.bodytok.healthdiary.dto.UserAccountDto;
+import com.bodytok.healthdiary.dto.userAccount.UserProfile;
 import com.bodytok.healthdiary.repository.UserAccountRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserAccountService {
 
     private final UserAccountRepository userAccountRepository;
+    private final PersonalExerciseDiaryService diaryService;
 
     @Transactional(readOnly = true)
     public UserAccount getUserById(Long id) {
@@ -35,6 +37,17 @@ public class UserAccountService {
     @Transactional(readOnly = true)
     public Boolean checkUserByNickname(String nickname) {
         return userAccountRepository.existsByNickname(nickname);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfile getUserProfile(Long userId) {
+        //1.유저 조회
+        //2. 다이어리 카운트 조회 후 profileInfo로 매핑
+        UserAccount userAccount = this.getUserById(userId);
+        int diaryCount = diaryService.getDiaryCount(userId);
+
+        UserProfile userProfile = UserProfile.toProfileInfo(userAccount, diaryCount);
+        return userProfile;
     }
 
 }


### PR DESCRIPTION
* UserAccount 엔티티에서 필요한 정보만 `UserProfile`에 매핑하여 리턴하였음.

TODO
* 유저 자기소개 필드 만들기
* 유저의 관심운동 필드 만들기

This closes #135 