### PR TITLE
운동, 루틴 조회 로직

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/ExerciseRoutineController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/ExerciseRoutineController.java
@@ -1,22 +1,21 @@
 package com.bodytok.healthdiary.controller;
 
-import com.bodytok.healthdiary.domain.ExerciseRoutine;
 import com.bodytok.healthdiary.domain.security.CustomUserDetails;
 import com.bodytok.healthdiary.dto.exercise_routine.ExerciseDto;
 import com.bodytok.healthdiary.dto.exercise_routine.RoutineDto;
 import com.bodytok.healthdiary.dto.exercise_routine.request.ExerciseCreate;
 import com.bodytok.healthdiary.dto.exercise_routine.request.RoutineCreate;
 import com.bodytok.healthdiary.dto.exercise_routine.response.ExerciseResponse;
+import com.bodytok.healthdiary.dto.exercise_routine.response.RoutineWithExerciseResponse;
 import com.bodytok.healthdiary.dto.exercise_routine.response.RoutineResponse;
 import com.bodytok.healthdiary.service.ExerciseRoutineService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -25,6 +24,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class ExerciseRoutineController {
 
     private final ExerciseRoutineService exRoutineService;
+
+    @GetMapping
+    public ResponseEntity<List<RoutineWithExerciseResponse>> getAllRoutine(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(name = "userId", required = false) Long userId
+    ){
+        /**
+         * TODO : 루틴 공개 해야하는 지 아닌 지 확인하고 비공개 or 공개 처리 로직 추가하기
+         * 일단 공개로 만들기
+         */
+        Long requestUserId = userId == null ? userDetails.getId() : userId;
+        List<RoutineDto> routineList = exRoutineService.getAllRoutine(requestUserId);
+        var response = routineList.stream().map(RoutineWithExerciseResponse::from).toList();
+        return ResponseEntity.ok().body(response);
+    }
 
     @PostMapping
     public ResponseEntity<RoutineResponse> saveRoutine(

--- a/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/ExerciseDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/ExerciseDto.java
@@ -1,7 +1,6 @@
 package com.bodytok.healthdiary.dto.exercise_routine;
 
 import com.bodytok.healthdiary.domain.Exercise;
-import com.bodytok.healthdiary.dto.UserAccountDto;
 
 public record ExerciseDto(
         Long id,

--- a/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/RoutineDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/RoutineDto.java
@@ -5,16 +5,17 @@ import com.bodytok.healthdiary.domain.Routine;
 import com.bodytok.healthdiary.dto.UserAccountDto;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record RoutineDto(
         Long id,
         String routineName,
         String memo,
         UserAccountDto userAccountDto,
-        List<ExerciseRoutine> exerciseRoutines
+        List<ExerciseDto> exerciseDtoList
 ) {
-        public static RoutineDto of(Long id, String routineName, String memo, UserAccountDto userAccountDto, List<ExerciseRoutine> exerciseRoutines) {
-                return new RoutineDto(id, routineName, memo, userAccountDto, exerciseRoutines);
+        public static RoutineDto of(Long id, String routineName, String memo, UserAccountDto userAccountDto, List<ExerciseDto> exerciseDtoList) {
+                return new RoutineDto(id, routineName, memo, userAccountDto, exerciseDtoList);
         }
 
         public static RoutineDto from(Routine entity) {
@@ -23,7 +24,10 @@ public record RoutineDto(
                         entity.getRoutineName(),
                         entity.getMemo(),
                         UserAccountDto.from(entity.getUserAccount()),
-                        entity.getExerciseRoutines()
+                        entity.getExerciseRoutines().stream()
+                                .map(ExerciseRoutine::getExercise)
+                                .map(ExerciseDto::from)
+                                .collect(Collectors.toList())
                 );
         }
 

--- a/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/response/RoutineResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/response/RoutineResponse.java
@@ -1,6 +1,5 @@
 package com.bodytok.healthdiary.dto.exercise_routine.response;
 
-import com.bodytok.healthdiary.domain.Routine;
 import com.bodytok.healthdiary.dto.exercise_routine.RoutineDto;
 
 public record RoutineResponse(

--- a/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/response/RoutineWithExerciseResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/exercise_routine/response/RoutineWithExerciseResponse.java
@@ -1,0 +1,31 @@
+package com.bodytok.healthdiary.dto.exercise_routine.response;
+
+import com.bodytok.healthdiary.dto.exercise_routine.RoutineDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record RoutineWithExerciseResponse(
+        Long id,
+        String routineName,
+        String memo,
+        List<ExerciseResponse> exerciseList,
+        Long userId
+) {
+
+    public static RoutineWithExerciseResponse of(Long id, String routineName, String memo, List<ExerciseResponse> exerciseList, Long userId) {
+        return new RoutineWithExerciseResponse(id, routineName, memo, exerciseList, userId);
+    }
+
+    public static RoutineWithExerciseResponse from(RoutineDto dto) {
+        return of(
+                dto.id(),
+                dto.routineName(),
+                dto.memo(),
+                dto.exerciseDtoList().stream()
+                        .map(ExerciseResponse::from)
+                        .collect(Collectors.toList()),
+                dto.userAccountDto().id()
+        );
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/repository/RoutineRepository.java
+++ b/src/main/java/com/bodytok/healthdiary/repository/RoutineRepository.java
@@ -8,11 +8,15 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 
+import java.util.List;
+
 public interface RoutineRepository extends
         JpaRepository<Routine, Long>,
         QuerydslPredicateExecutor<Routine>,
         QuerydslBinderCustomizer<QRoutine>
 {
+    List<Routine> findAllByUserAccount_Id(Long userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QRoutine root) {
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/bodytok/healthdiary/service/ExerciseRoutineService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/ExerciseRoutineService.java
@@ -5,12 +5,10 @@ import com.bodytok.healthdiary.domain.Exercise;
 import com.bodytok.healthdiary.domain.ExerciseRoutine;
 import com.bodytok.healthdiary.domain.Routine;
 import com.bodytok.healthdiary.domain.UserAccount;
-import com.bodytok.healthdiary.dto.UserAccountDto;
 import com.bodytok.healthdiary.dto.exercise_routine.ExerciseDto;
 import com.bodytok.healthdiary.dto.exercise_routine.RoutineDto;
 import com.bodytok.healthdiary.dto.exercise_routine.request.ExerciseCreate;
 import com.bodytok.healthdiary.dto.exercise_routine.request.RoutineCreate;
-import com.bodytok.healthdiary.dto.exercise_routine.response.RoutineResponse;
 import com.bodytok.healthdiary.repository.ExerciseRepository;
 import com.bodytok.healthdiary.repository.ExerciseRoutineRepository;
 import com.bodytok.healthdiary.repository.RoutineRepository;
@@ -18,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Transactional
@@ -29,6 +30,12 @@ public class ExerciseRoutineService {
     private final RoutineRepository routineRepository;
     private final ExerciseRoutineRepository exerciseRoutineRepository;
     private final UserAccountService userAccountService;
+
+    @Transactional(readOnly = true)
+    public List<RoutineDto> getAllRoutine(Long requestUserId) {
+        List<Routine> routines = routineRepository.findAllByUserAccount_Id(requestUserId);
+        return routines.stream().map(RoutineDto::from).collect(Collectors.toList());
+    }
 
     public RoutineDto saveRoutine(RoutineCreate routineCreate, Long userId){
         UserAccount  userAccount = userAccountService.getUserById(userId);


### PR DESCRIPTION
-> `@OneToMany` 필드로 돼있는 exerciseRoutines 의 엔티티는 각 부모의 필드가 Lazy Loading 으로 되어 있다. 
**따라서 컨트롤러로 넘어가기 전에, 서비스 코드의 트랜잭션 내에서 getExercise 로 dto 에서 매핑한다.**

This closes #133 