### PR TITLE
유저 프로필 정보 조회 api

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/controller/UserController.java
+++ b/src/main/java/com/bodytok/healthdiary/controller/UserController.java
@@ -2,13 +2,20 @@ package com.bodytok.healthdiary.controller;
 
 
 import com.bodytok.healthdiary.domain.security.CustomUserDetails;
+import com.bodytok.healthdiary.dto.diary.response.DiaryResponse;
 import com.bodytok.healthdiary.dto.userAccount.UserProfile;
 import com.bodytok.healthdiary.service.UserAccountService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -20,9 +27,16 @@ public class UserController {
     private final UserAccountService userAccountService;
 
     @GetMapping
+    @Operation(summary = "유저 프로필 정보 조회")
+    @ApiResponse(responseCode = "200", description = "OK", content = {
+            @Content(mediaType = "application/json", schema = @Schema(implementation = UserProfile.class))
+    })
     public UserProfile userProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(name = "userId", description = "조회하는 유저 ID")
+            @RequestParam(name = "userId", required = false) Long userId
     ) {
-        return userAccountService.getUserProfile(userDetails.getId());
+        Long requestUserId = userId == null ? userDetails.getId() : userId;
+        return userAccountService.getUserProfile(requestUserId);
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/service/UserAccountService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/UserAccountService.java
@@ -39,6 +39,8 @@ public class UserAccountService {
         return userAccountRepository.existsByNickname(nickname);
     }
 
+
+    // TODO : 팔로우 카운트만 조회하려면 커스텀 쿼리를 작성해야함.
     @Transactional(readOnly = true)
     public UserProfile getUserProfile(Long userId) {
         //1.유저 조회
@@ -46,8 +48,6 @@ public class UserAccountService {
         UserAccount userAccount = this.getUserById(userId);
         int diaryCount = diaryService.getDiaryCount(userId);
 
-        UserProfile userProfile = UserProfile.toProfileInfo(userAccount, diaryCount);
-        return userProfile;
+        return UserProfile.toProfileInfo(userAccount, diaryCount);
     }
-
 }


### PR DESCRIPTION
refactoring : 다른 유저 ID 로 프로필 조회할 수 있도록 수정

# TODO
* 팔로우 카운트를 그냥 list.size() 로 가져오고 있기 때문에 엔티티 row 를 조회하는 쿼리가 발생한다.
-> 커스텀 쿼리 작성으로 count() 를 사용하도록 리팩토링 해야함.