### PR TITLE
refactoring : 내 프로필 팔로우조회 관계처리 수정

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/domain/Follow.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/Follow.java
@@ -1,10 +1,10 @@
 package com.bodytok.healthdiary.domain;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Getter;
+import lombok.ToString;
 
 
-@ToString(callSuper = true)
 @Getter
 @Entity
 public class Follow extends AuditingFields {

--- a/src/main/java/com/bodytok/healthdiary/service/FollowService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/FollowService.java
@@ -45,11 +45,14 @@ public class FollowService {
     // 유저가 팔로잉 하고 있는 유저들 조회 (유저 -> 유저)
     @Transactional(readOnly = true)
     public List<FollowResponse> followingList(CustomUserDetails userDetails, Long userId) {
+        Long myId = userDetails.getId();
+        boolean isMyId = myId.equals(userId);
+
         UserAccount user = userAccountService.getUserById(userId);
         return user.getFollowingList().stream()
                 .map(follow -> {
                     var followingUser = follow.getFollowing();
-                    FollowStatus association = association(userDetails.getId(), userId);
+                    FollowStatus association = isMyId ? FollowStatus.FOLLOW : association(myId, userId);
                     return FollowResponse.fromUserEntity(followingUser, association);
                 })
                 .collect(Collectors.toList());
@@ -60,11 +63,14 @@ public class FollowService {
     //유저를 팔로잉 하고 있는 유저들 조회 (유저 <- 유저)
     @Transactional(readOnly = true)
     public List<FollowResponse> followerList(CustomUserDetails userDetails, Long userId) {
+        Long myId = userDetails.getId();
+        boolean isMyId = myId.equals(userId);
+
         UserAccount user = userAccountService.getUserById(userId);
         return user.getFollowerList().stream()
                 .map(follow -> {
                     var usersFollower = follow.getFollower();
-                    FollowStatus association = association(userDetails.getId(), userId);
+                    FollowStatus association = isMyId ? FollowStatus.FOLLOW :association(myId, userId);
                     return FollowResponse.fromUserEntity(usersFollower, association);
                 })
                 .collect(Collectors.toList());
@@ -89,10 +95,10 @@ public class FollowService {
         if (userId.equals(myId)){
             return FollowStatus.SELF;
         }
-        if (!followRepository.existsFollowByFollowerIdAndFollowingId(myId, userId)){
-            return FollowStatus.NONE;
+        if (followRepository.existsFollowByFollowerIdAndFollowingId(myId, userId)){
+            return FollowStatus.FOLLOW;
 
         }
-        return FollowStatus.FOLLOW;
+        return FollowStatus.NONE;
     }
 }


### PR DESCRIPTION
내 `association()` 을 통해 팔로우 리스트로 조회된 유저와의 관계를 구할 때, path variable 로 넘어온 userId 와 내 아이디를 구별하지 않아서 모두 `SELF` 로 나왔음. 구별되도록 수정하였음