### PR TITLE
ffx - 프로필 인스턴스 초기화 문제로 인한 Null 예외 수정

### DIFF
--- a/src/main/java/com/bodytok/healthdiary/dto/userAccount/FollowResponse.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/userAccount/FollowResponse.java
@@ -1,9 +1,10 @@
 package com.bodytok.healthdiary.dto.userAccount;
 
+import com.bodytok.healthdiary.domain.ProfileImage;
 import com.bodytok.healthdiary.domain.UserAccount;
 import com.bodytok.healthdiary.domain.constant.FollowStatus;
-import com.bodytok.healthdiary.dto.Image.ProfileImageDtoImpl;
 import com.bodytok.healthdiary.dto.Image.ImageResponse;
+import com.bodytok.healthdiary.dto.Image.ProfileImageDtoImpl;
 
 
 public record FollowResponse(
@@ -14,13 +15,16 @@ public record FollowResponse(
         FollowStatus followStatus
 ) {
 
-    public static FollowResponse fromUserEntity(UserAccount userAccount, FollowStatus followStatus){
+    public static FollowResponse fromUserEntity(UserAccount userAccount, FollowStatus followStatus) {
         return new FollowResponse(
                 userAccount.getId(),
                 userAccount.getEmail(),
                 userAccount.getNickname(),
                 ImageResponse.from(
-                        ProfileImageDtoImpl.from(userAccount.getProfileImage())
+                        ProfileImageDtoImpl.from(
+                                userAccount.getProfileImage() == null ?
+                                        new ProfileImage() : userAccount.getProfileImage()
+                        )
                 ),
                 followStatus
         );

--- a/src/main/java/com/bodytok/healthdiary/dto/userAccount/UserAccountDto.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/userAccount/UserAccountDto.java
@@ -35,7 +35,7 @@ public record UserAccountDto(
                 .userPassword(entity.getUserPassword())
                 .profileImage(ProfileImageDtoImpl.from(
                         entity.getProfileImage() == null ?
-                        ProfileImage.builder().build() : entity.getProfileImage()
+                                new ProfileImage() : entity.getProfileImage()
                 ))
                 .createdAt(entity.getCreatedAt())
                 .modifiedAt(entity.getModifiedAt())

--- a/src/main/java/com/bodytok/healthdiary/dto/userAccount/response/UserProfile.java
+++ b/src/main/java/com/bodytok/healthdiary/dto/userAccount/response/UserProfile.java
@@ -1,6 +1,7 @@
 package com.bodytok.healthdiary.dto.userAccount.response;
 
 
+import com.bodytok.healthdiary.domain.ProfileImage;
 import com.bodytok.healthdiary.domain.UserAccount;
 import com.bodytok.healthdiary.domain.constant.FollowStatus;
 import com.bodytok.healthdiary.dto.Image.ImageResponse;
@@ -50,7 +51,9 @@ public record UserProfile(
                 .email(userAccount.getEmail())
                 .profileImage(
                         ImageResponse.from(
-                                ProfileImageDtoImpl.from(userAccount.getProfileImage()))
+                                ProfileImageDtoImpl.from(
+                                        userAccount.getProfileImage() == null ?
+                                        new ProfileImage() : userAccount.getProfileImage()))
                 )
                 .followerCount(userAccount.getFollowerList().size())
                 .followingCount(userAccount.getFollowingList().size())


### PR DESCRIPTION
entity 에서 response 객체로 매핑 시 ProfileImage 인스턴스 생성 초기화

This closes #163 