### PR TITLE
로그인 / 리프레시 관련 리팩토링 & 유저정보 레디스 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
 	// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	//유효성 검사
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/bodytok/healthdiary/config/RedisConfiguration.java
+++ b/src/main/java/com/bodytok/healthdiary/config/RedisConfiguration.java
@@ -2,21 +2,90 @@ package com.bodytok.healthdiary.config;
 
 import com.bodytok.healthdiary.domain.JwtToken;
 import com.bodytok.healthdiary.repository.jwt.JwtTokenRepository;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableCaching
 @Configuration
-@EnableRedisRepositories(basePackageClasses = {JwtTokenRepository.class})
+@EnableRedisRepositories(
+        basePackageClasses = {JwtTokenRepository.class},
+        enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP
+)
 public class RedisConfiguration {
 
-    @Bean
-    public RedisTemplate<String, JwtToken> getRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, JwtToken> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
+    @Value("${spring.data.redis.host}")
+    private String host;
 
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+        return new LettuceConnectionFactory(standaloneConfiguration);
+    }
+
+    //RefreshToken 저장을 위한 template
+    @Bean
+    public RedisTemplate<String, JwtToken> getRedisTemplate() {
+        RedisTemplate<String, JwtToken> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory){
+
+        // 캐시의 기본 설정
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()  // null 값은 캐싱X
+                .entryTtl(Duration.ofMinutes(10L))  // 캐시 유효 시간 설정
+                .computePrefixWith(CacheKeyPrefix.simple())  // 캐시 키의 접두어를 간단하게 계산 EX) UserCacheStore::Key 의 형태로 저장
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))  // 키의 직렬화 방식 설정
+                // CustomUserDetails 의 부가적인 필드들의 오류를 ignore
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer().configure(
+                                objectMapper -> objectMapper.configure(
+                                        DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false
+                                )
+                        )
+                ));  // 값의 직렬화 방식 설정
+
+        Map<String, RedisCacheConfiguration> redisCacheConfigurationMap = new HashMap<>();
+        redisCacheConfigurationMap.put("AuthCacheStore", redisCacheConfiguration);
+        // RedisCacheManager 리턴
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)  // Redis 연결 설정
+                .cacheDefaults(redisCacheConfiguration)  // 기본 캐시 설정
+                .withInitialCacheConfigurations(redisCacheConfigurationMap)
+                .build();  // RedisCacheManager 생성
+
+
     }
 }

--- a/src/main/java/com/bodytok/healthdiary/config/security/AuthConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/AuthConfig.java
@@ -1,18 +1,12 @@
 package com.bodytok.healthdiary.config.security;
 
 
-import com.bodytok.healthdiary.domain.security.CustomUserDetails;
-import com.bodytok.healthdiary.dto.userAccount.UserAccountDto;
-import com.bodytok.healthdiary.exepction.CustomBaseException;
-import com.bodytok.healthdiary.exepction.CustomError;
-import com.bodytok.healthdiary.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -20,21 +14,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RequiredArgsConstructor
 public class AuthConfig {
 
-    private final UserAccountRepository userAccountRepository;
+    private final CustomUserDetailService customUserDetailService;
 
     @Bean
-    public UserDetailsService userDetailsService(){
-
-        return username -> userAccountRepository.findByEmail(username)
-                .map(UserAccountDto::from)
-                .map(CustomUserDetails::from)
-                .orElseThrow(() -> new CustomBaseException(CustomError.USER_NOT_FOUND));
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager() throws Exception {
+    public AuthenticationManager authenticationManager() {
         DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setUserDetailsService(customUserDetailService);
         authProvider.setPasswordEncoder(passwordEncoder());
         return new ProviderManager(authProvider);
     }

--- a/src/main/java/com/bodytok/healthdiary/config/security/CustomUserDetailService.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/CustomUserDetailService.java
@@ -1,0 +1,33 @@
+package com.bodytok.healthdiary.config.security;
+
+import com.bodytok.healthdiary.domain.security.CustomUserDetails;
+import com.bodytok.healthdiary.dto.userAccount.UserAccountDto;
+import com.bodytok.healthdiary.exepction.CustomBaseException;
+import com.bodytok.healthdiary.exepction.CustomError;
+import com.bodytok.healthdiary.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserAccountRepository userAccountRepository;
+
+
+    @Cacheable(value = "AuthCacheStore",key = "#username")
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info(">>>CustomUserDetailService - username :{}", username);
+        return userAccountRepository.findByEmail(username)
+                .map(UserAccountDto::from)
+                .map(CustomUserDetails::from)
+                .orElseThrow(() -> new CustomBaseException(CustomError.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
+++ b/src/main/java/com/bodytok/healthdiary/config/security/SecurityConfig.java
@@ -51,7 +51,6 @@ public class SecurityConfig {
                                 .requestMatchers("swagger-ui/**").permitAll()
                                 .requestMatchers("webjars/**").permitAll()
                                 .requestMatchers("swagger-ui.html").permitAll()
-
                 )
                 .authorizeHttpRequests(
                         auth -> auth

--- a/src/main/java/com/bodytok/healthdiary/domain/JwtToken.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/JwtToken.java
@@ -34,11 +34,6 @@ public class JwtToken {
         this.tokenType = tokenType;
         this.expiration = expiration;
     }
-    private JwtToken(String token, TokenType tokenType) {
-        this.token = token;
-        this.tokenType = tokenType;
-    }
-
     public static JwtToken of(String token, TokenType tokenType) {
         return new JwtToken(token, tokenType,null);
     }

--- a/src/main/java/com/bodytok/healthdiary/domain/security/CustomUserDetails.java
+++ b/src/main/java/com/bodytok/healthdiary/domain/security/CustomUserDetails.java
@@ -2,6 +2,7 @@ package com.bodytok.healthdiary.domain.security;
 
 import com.bodytok.healthdiary.domain.UserAccount;
 import com.bodytok.healthdiary.dto.userAccount.UserAccountDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,7 @@ public class CustomUserDetails implements UserDetails {
     private String nickname;
     private String userPassword;
 
+    @JsonIgnore
     private Collection<? extends GrantedAuthority> authorities;
 
 

--- a/src/main/java/com/bodytok/healthdiary/exepction/CustomError.java
+++ b/src/main/java/com/bodytok/healthdiary/exepction/CustomError.java
@@ -8,6 +8,15 @@ import lombok.RequiredArgsConstructor;
 public enum CustomError {
 
     /**
+     * Auth
+     */
+    REFRESH_TOKEN_NULL(400, "AUTH_001", "요청에 리프레시 토큰이 없습니다."),
+    TOKEN_NOT_FOUND(404, "AUTH_002", "토큰을 찾을 수 없습니다."),
+    TOKEN_EXTRACT_FAILED(401, "AUTH_003", "사용할 수 없거나 잘못된 토큰입니다."),
+    TOKEN_NOT_VALID(400, "AUTH_004", "만료되거나 잘못된 토큰입니다."),
+    REFRESH_LOGOUT(400, "AUTH_005", "다시 로그인이 필요합니다."),
+    REFRESH_FAILED(500, "AUTH_006", "리프레시 요청이 실패했습니다."),
+    /**
      * User
      */
     USER_NOT_FOUND(404, "USER_001", "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/bodytok/healthdiary/service/auth/jwt/JwtService.java
+++ b/src/main/java/com/bodytok/healthdiary/service/auth/jwt/JwtService.java
@@ -21,6 +21,7 @@ public class JwtService {
 
     @Value("${jwt.access-token.expiration}")
     long accessExpiration;
+
     @Value("${jwt.refresh-token.expiration}")
     long refreshExpiration;
     public JwtToken getToken(String token) {
@@ -28,19 +29,15 @@ public class JwtService {
     }
 
 
-    public JwtToken saveToken(JwtToken token) {
+    public void saveToken(JwtToken token) {
         //access 인지 refresh 인지 구분해서 expiration 저장
         long expirationTime = (token.getTokenType() == TokenType.ACCESS) ? accessExpiration : refreshExpiration;
 
-
-        // Set expiration time to JwtToken object
         token.setExpiration(expirationTime);
-
-        return jwtTokenRepository.save(token);
+        jwtTokenRepository.save(token);
     }
 
-    public void deleteToken(String token, String refreshToken) {
+    public void deleteToken(String token){
         jwtTokenRepository.deleteById(token);
-        jwtTokenRepository.deleteById(refreshToken);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ jwt:
   access-token:
     expiration: 3600000
   refresh-token:
-    expiration: 86400000
+    expiration: 18000000
 spring:
   profiles:
     include: aws
@@ -43,6 +43,10 @@ spring:
     init:
       mode: always
       encoding: UTF-8
+  data:
+    redis:
+      host: localhost
+      port: 6379
   devtools:
     livereload:
       enabled: false
@@ -56,14 +60,14 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
       resolve-lazily: true
-    redis:
-      host: localhost
-      port: 6379
 springdoc:
+  api-docs:
+    path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui
     display-request-duration: true
-
+    disable-swagger-default-url: true
+    url: /v3/api-docs
 #--- test ?? ???
 #
 #spring:


### PR DESCRIPTION
## Problem
* `jwtAuthenticationFilter` 의 인증 로직이 제대로 되는지 한 번 검증해 필요
    * `loadUserByUsername` 를 통한 db 조회가 매우 자주 일어남

* 로그인 시  jwt 빌드 문제
    * jwt build 시 accessToken 과 refreshToken 이 같은 String 으로 만들어짐
* 토큰 재발행 시 refreshToken 은 재발행을 안 하고 있었음.
---
## Solve
* `jwtAuthenticationFilter` 에서 쓰이는 `loadUserByUsername` 에 Redis 캐싱 적용
* jwt build 시 expiration claim 을 추가해 다른 String 으로 만들어지게 함
* 토큰 재발행시 accessToken 과 refreshToken 같이 발급

### Feature
* RedisConfiguration : 캐싱 관련 설정
    * `@EnableRedisRepositories` 에서  `enableKeyspaceEvents` 을 통해 만료된 키를 자동삭제하게 함.
* CustomUserDetailService : 유저 정보를 조회하는 로직에 캐싱을 적용하기 위해 메소드로 따로 구성
